### PR TITLE
Support rems

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { createPlugin, utils } from 'stylelint'
 
-import { validBase, hasPixelValue, validPixelValue } from './utils'
+import { validBase, hasSupportedValue, validSupportedValue } from './utils'
 
 const { ruleMessages, validateOptions, report } = utils
 
@@ -47,7 +47,7 @@ const pattern = (props: string[]): RegExp =>
 const ignorePattern = new RegExp(ignoreList.join('|'))
 
 const valid = (value: string): boolean =>
-  hasPixelValue(value) && !String(value).match(ignorePattern)
+  hasSupportedValue(value) && !String(value).match(ignorePattern)
 
 const messages = ruleMessages(ruleName, {
   invalid: (prop, actual, base) =>
@@ -61,7 +61,7 @@ const { rule } = createPlugin(ruleName, (primaryOption) => {
       possible: {
         base: validBase,
         ignore: blacklist,
-        whitelist: hasPixelValue,
+        whitelist: hasSupportedValue,
       },
     })
     if (!validOptions) return
@@ -73,7 +73,7 @@ const { rule } = createPlugin(ruleName, (primaryOption) => {
 
     postcssRoot.walkDecls(pattern(props), (decl) => {
       if (!valid(decl.value)) return
-      if (!validPixelValue(decl.value, primaryOption.base, whitelist)) {
+      if (!validSupportedValue(decl.value, primaryOption.base, whitelist)) {
         report({
           ruleName: ruleName,
           result: postcssResult,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,29 +1,30 @@
 type WhitelistType = string[] | undefined
 
-export const validBase = (base: number): boolean => base % 1 == 0
+export const validBase = (base: number): boolean => base > 0
 
-export const hasPixelValue = (value: string): boolean =>
-  String(value).includes('px')
+export const hasSupportedValue = (value: string): boolean =>
+  String(value).includes('px') || String(value).includes('rem')
 
 const isWhitelist = (whitelist: WhitelistType, value: string): boolean =>
   (whitelist && whitelist.includes(value)) || false
 
 const divisibleBy = (value: string, base: number): boolean => {
-  const number = value.match(/\d+/)
-  return Number(number) % Number(base) === 0
+  // parseFloat() drops units at the end automatically
+  const number = parseFloat(value)
+  return number % Number(base) === 0
 }
 
-export const validPixelValue = (
+export const validSupportedValue = (
   value: string,
   base: number,
   whitelist: WhitelistType
 ): boolean => {
   return (
-    // handle multiple px values
+    // handle multiple size values
     //   e.g. padding: 8px 8px 1px 8px or padding: 3em 8px 8px 8px;
     value
       .split(/[\s\r\n]+/)
-      .filter(hasPixelValue)
+      .filter(hasSupportedValue)
       .every(
         (value) => isWhitelist(whitelist, value) || divisibleBy(value, base)
       )

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,2 +1,3 @@
 import './baseConfig'
 import './extendedConfig'
+import './remConfig'

--- a/tests/remConfig.ts
+++ b/tests/remConfig.ts
@@ -1,0 +1,44 @@
+import testRule from 'stylelint-test-rule-tape'
+import { rule, ruleName, messages } from '../src/index'
+
+const base = 0.5
+
+testRule(rule, {
+  ruleName: ruleName,
+  config: {
+    base,
+    whitelist: ['1px'],
+    ignore: ['width', 'max-height', 'margin-bottom'],
+  },
+
+  accept: [
+    { code: '.generic-card { margin-left: 0.5rem; }' },
+    { code: '.generic-card { padding-top: 4rem; }' },
+    { code: '.generic-card { width: 0.3125rem; }' },
+    { code: '.generic-card { height: 1rem; }' },
+    { code: '.generic-card { margin-left: 1px; }' },
+    { code: '.generic-card { padding: 1px 0.5rem 1.5rem 2rem; }' },
+    { code: '.generic-card { margin: 1rem 0; }' },
+    { code: '.generic-card { max-height: 1rem; }' },
+    { code: '.generic-card { margin-bottom: 2rem; }' },
+  ],
+
+  reject: [
+    {
+      code: '.generic-card { padding-left: 0.125rem; }',
+      message: messages.invalid('padding-left', '0.125rem', base),
+    },
+    {
+      code: '.generic-card { height: 0.1875rem; }',
+      message: messages.invalid('height', '0.1875rem', base),
+    },
+    {
+      code: '.generic-card { margin: 0.5rem 0.6875rem; }',
+      message: messages.invalid('margin', '0.5rem 0.6875rem', base),
+    },
+    {
+      code: '.generic-card { margin: 1px 0.125rem 2rem 1.5rem; }',
+      message: messages.invalid('margin', '1px 0.125rem 2rem 1.5rem', base),
+    },
+  ],
+})


### PR DESCRIPTION
Fully fixes #23 

- Support fractional base, e.g. 0.25
- Don't filter out `rem`s (before only `px` was considered)
- Fix parsing to parse floating point numbers (regex didn't handle floating point, changed to `parseFloat()`)
- Add tests